### PR TITLE
tests: set linux_latest as the default kernel

### DIFF
--- a/tests/build-profile.nix
+++ b/tests/build-profile.nix
@@ -1,10 +1,14 @@
 { profile }:
 
 let
-  shim = { config, ... }: {
+  shim = { config, lib, pkgs, ... }: {
     boot.loader.systemd-boot.enable = !config.boot.loader.generic-extlinux-compatible.enable && !config.boot.loader.raspberryPi.enable;
     # we forcefully disable grub here just for testing purposes, even though some profiles might still use grub in the end.
     boot.loader.grub.enable = false;
+
+    # so we can have assertions that require a certain minimum kernel version,
+    # We use a priority of 1200 here, which is higher than the default of 1000
+    boot.kernelPackages = lib.mkOverride 1200 pkgs.linuxPackages_latest;
 
     fileSystems."/" = {
       device = "/dev/disk/by-uuid/00000000-0000-0000-0000-000000000000";


### PR DESCRIPTION
###### Description of changes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested the changes in your own NixOS Configuration
- [ ] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

